### PR TITLE
Fun-projects page redesign + fixes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1107,12 +1107,7 @@ document.addEventListener('DOMContentLoaded', () => {
              }
             // Add similar logic for the back button if desired
             else if (isFunProjectsPage && targetLink.id === 'back-btn') {
-                 event.preventDefault();
-                 document.body.style.transition = 'opacity 0.5s ease-out';
-                 document.body.style.opacity = 0;
-                 setTimeout(() => {
-                     window.location.href = targetLink.href;
-                 }, 500);
+                 // Handled by dedicated back-btn click listener — skip here
             }
         }
     });
@@ -1122,11 +1117,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (backBtn && isFunProjectsPage) {
         backBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            if (!isTransitioningBack) {
-                isTransitioningBack = true;
-                backTransitionStartTime = performance.now();
-                currentLookAt = camera.getWorldDirection(new THREE.Vector3());
-            }
+            e.stopPropagation();
+            window.location.href = '../#tiles';
         });
     }
 


### PR DESCRIPTION
## Summary
- Redesigned fun-projects page to match main projects page gallery layout
- Converted all project preview images to WebP with responsive srcset
- Removed Trump Tariff Tracker project, centered Market Compass for symmetry
- Fixed broken Back to Home button — now navigates instantly
- Fixed relative asset paths that were causing blank page

## Changes
- `fun-projects/index.html` — full rewrite with `.gallery-grid` structure
- `style.css` — added centering rule for last card in 3-col grid
- `script.js` — simplified back button to instant navigation
- Added 10 WebP image files (desktop + mobile variants)
- Deleted duplicate root `fun-projects.html`

## Test plan
- [ ] Verify 3-column gallery layout on desktop
- [ ] Verify Market Compass centered in second row
- [ ] Verify Back to Home button navigates instantly
- [ ] Verify responsive layout on mobile (1-column)
- [ ] Verify all project card links open correctly